### PR TITLE
Reimplemented ball minimum speed

### DIFF
--- a/game/Scenes/Gameplay.tscn
+++ b/game/Scenes/Gameplay.tscn
@@ -87,9 +87,9 @@ ring_exit_trauma = 0.4
 [node name="GameFinished" type="Timer" parent="."]
 wait_time = 3.0
 one_shot = true
-[connection signal="body_exited" from="Ring" to="PowerupGenerator" method="_on_Ring_body_exited"]
-[connection signal="body_exited" from="Ring" to="ShakeCamera2D" method="_on_Ring_body_exited"]
 [connection signal="body_exited" from="Ring" to="." method="_on_Ring_body_exited"]
+[connection signal="body_exited" from="Ring" to="ShakeCamera2D" method="_on_Ring_body_exited"]
+[connection signal="body_exited" from="Ring" to="PowerupGenerator" method="_on_Ring_body_exited"]
 [connection signal="player_won" from="Player1" to="." method="_on_player_won"]
 [connection signal="player_won" from="Player2" to="." method="_on_player_won"]
 [connection signal="body_entered" from="Ball" to="ShakeCamera2D" method="_on_Ball_body_entered"]
@@ -100,7 +100,7 @@ one_shot = true
 [connection signal="body_exited" from="AreaElectric2" to="." method="_on_AreaElectric2_body_exited"]
 [connection signal="timeout" from="ElecAttTimer2" to="." method="_on_ElecAttTimer2_timeout"]
 [connection signal="taken_elec_att" from="PowerupGenerator" to="." method="_on_PowerupGenerator_taken_elec_att"]
-[connection signal="taken_magnetic" from="PowerupGenerator" to="Ball" method="execute_magnetic"]
 [connection signal="taken_magnetic" from="PowerupGenerator" to="." method="_on_PowerupGenerator_taken_magnetic"]
+[connection signal="taken_magnetic" from="PowerupGenerator" to="Ball" method="execute_magnetic"]
 [connection signal="taken_polarity_inverter" from="PowerupGenerator" to="Ball" method="change_polarity"]
 [connection signal="timeout" from="GameFinished" to="." method="_on_GameFinished_timeout"]

--- a/game/Scripts/Ball.gd
+++ b/game/Scripts/Ball.gd
@@ -8,6 +8,8 @@ export var max_speed: float= 200
 export var charge: float = 1
 var _position_reset_needed := false
 var _velocity_reset_needed := false
+var _pad_normal: Vector2
+var _velocity_normalization_needed := false
 var magnetic_active = 0
 var elec_att_active_p1 = 0
 var elec_att_active_p2 = 0
@@ -21,6 +23,8 @@ var last_hit_player: Player = null
 
 func _ready():
 	can_sleep = false
+	contact_monitor = true
+	contacts_reported = 1
 	set_sprite()
 	reset()
 	$Trail.start()
@@ -68,10 +72,13 @@ func _integrate_forces(state: Physics2DDirectBodyState) -> void:
 		set_applied_force(-charge*E*Vector2(cos(angle_p1), sin(angle_p1)) + charge*B*Vector2(linear_velocity.y, -linear_velocity.x) - charge*E*Vector2(cos(angle_p2), sin(angle_p2)))
 	else:
 		set_applied_force(Vector2(0, 0))
-	
-	#set a minimum velocity when the ball is moving to avoid problems when the ball is reseted
-	if sqrt(linear_velocity.dot(linear_velocity)) < min_speed and sqrt(linear_velocity.dot(linear_velocity)) > 1:
-		state.set_linear_velocity(linear_velocity.normalized() * min_speed)
+
+	if _velocity_normalization_needed:
+		if linear_velocity.is_equal_approx(Vector2.ZERO):
+			linear_velocity = _pad_normal * min_speed
+		elif linear_velocity.length() < min_speed:
+			linear_velocity = linear_velocity.normalized() * min_speed
+		_velocity_normalization_needed = false
 
 func set_sprite():
 	if (charge >= 0):
@@ -104,6 +111,8 @@ func _on_Magnetic_Timer_timeout():
 
 func _on_Ball_body_entered(body):
 	last_hit_player = body
+	_velocity_normalization_needed = true
+	_pad_normal = (center_of_screen - body.position).normalized()
 
 func get_last_hit_player() -> Player:
 	return last_hit_player


### PR DESCRIPTION
The problem with the previous implementation was that the speed was
checked everytime, not only after collisions. This resulted in a ball
that couldn't turn even if it was exposed to fields.

This implementation checks the speed only after a collision.